### PR TITLE
Fix file extension comparison case sensitivity

### DIFF
--- a/src/Fink.Abstractions.Tests/FilePathExtensionsTests.cs
+++ b/src/Fink.Abstractions.Tests/FilePathExtensionsTests.cs
@@ -58,4 +58,14 @@ public class FilePathExtensionsTests(TemporaryFileFixture fixture) : IClassFixtu
 
         Assert.Equal(filePath, result);
     }
+
+    [Fact]
+    public void AssertFilePathHasExtension_IgnoresExtensionCase_ReturnsFilePath()
+    {
+        FilePath filePath = Path.Combine(Path.GetTempPath(), "file.txt");
+
+        FilePath result = filePath.AssertFilePathHasExtension(".TXT");
+
+        Assert.Equal(filePath, result);
+    }
 }

--- a/src/Fink.Abstractions/FilePathExtensions.cs
+++ b/src/Fink.Abstractions/FilePathExtensions.cs
@@ -8,7 +8,7 @@ public static class FilePathExtensions
             : throw new FileNotFoundException($"File not found at path '{filePath}'");
 
     public static FilePath AssertFilePathHasExtension(this FilePath filePath, string extension) =>
-        Path.GetExtension(filePath) == extension
+        Path.GetExtension(filePath).Equals(extension, StringComparison.OrdinalIgnoreCase)
             ? filePath
             : throw new ArgumentException($"Path '{filePath}' does not have extension {extension}");
 }


### PR DESCRIPTION
## Summary
- avoid case-sensitive file extension comparisons
- add test verifying extension check is case-insensitive