### PR TITLE
Remove global tool doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,10 @@ GitHub Actions workflow includes:
 
 Fink is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
 
+## 🗺️ Roadmap
+
+- [ ] Global Tool Support - distribute Fink as a `.NET` global tool. (tracking issue to be created)
+
 ## 🐛 Issues & Support
 
 - **Bug Reports**: [Create an issue](https://github.com/tarurar/fink/issues/new?template=bug_report.md)


### PR DESCRIPTION
## Summary
- remove docs/tasks/global-tool-support.md
- note that global tool work will be tracked in a GitHub issue
- keep roadmap entry with placeholder for future tracking

## Testing
- `dotnet test ./src/Fink.sln --configuration Release --verbosity normal`
- Attempted `gh issue create` but authentication failed

------
https://chatgpt.com/codex/tasks/task_e_6842ae9cff08832fb460759baac1df96