### PR TITLE
Fix test method typo

### DIFF
--- a/src/Fink.Abstractions.Tests/DependencyTests.cs
+++ b/src/Fink.Abstractions.Tests/DependencyTests.cs
@@ -12,7 +12,7 @@ public class DependencyTests
     }
 
     [Fact]
-    public void When_ParentDepdendencyProvided_Then_PathIsCreatedWithMultipleSegments()
+    public void When_ParentDependencyProvided_Then_PathIsCreatedWithMultipleSegments()
     {
         Dependency parentDependency = new(new("parent"));
         Dependency dependency = new(new("dependency"), ParentDependency: parentDependency);


### PR DESCRIPTION
## Summary
- correct `When_ParentDepdendencyProvided_Then_PathIsCreatedWithMultipleSegments` test name

## Testing
- `dotnet test src/Fink.sln`

------
https://chatgpt.com/codex/tasks/task_e_6842b7a800d8832faa6172364fad069b