### PR TITLE
Add Tap extension and rename BuildalyzerBuildSuccess

### DIFF
--- a/src/Fink.Abstractions/ResultFunctionalExtensions.cs
+++ b/src/Fink.Abstractions/ResultFunctionalExtensions.cs
@@ -29,4 +29,12 @@ public static class ResultFunctionalExtensions
                 $"Result {result.GetType().Name} must implement ISuccessResult or IErrorResult")
         };
     }
+
+    public static Result Tap(this Result result, Action<Result> action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        action(result);
+        return result;
+    }
 }

--- a/src/Fink.Integrations.Buildalyzer/BuildalyzerBuildResult.cs
+++ b/src/Fink.Integrations.Buildalyzer/BuildalyzerBuildResult.cs
@@ -14,7 +14,7 @@ public sealed record BuildalyzerBuildError(
     public int ExitCode => ExitCodes.InternalError;
 }
 
-public sealed record BuildalyzertBuildSuccess(
+public sealed record BuildalyzerBuildSuccess(
     FilePath ProjectFilePath,
     FilePath LockFilePath,
     string TargetFramework,

--- a/src/Fink.Integrations.Buildalyzer/ProjectBuilder.cs
+++ b/src/Fink.Integrations.Buildalyzer/ProjectBuilder.cs
@@ -22,7 +22,7 @@ public static class ProjectBuilder
                 out string buildLog)
             .Select(r => (BuildalyzerBuildResult)(r switch
             {
-                { Succeeded: true } => new BuildalyzertBuildSuccess(
+                { Succeeded: true } => new BuildalyzerBuildSuccess(
                     projectFilePath,
                     r.GetProjectAssetsFilePathOrThrow(),
                     r.TargetFramework,

--- a/src/Fink/Program.cs
+++ b/src/Fink/Program.cs
@@ -18,10 +18,11 @@ internal sealed class Program
 
         var result = args.Validate()
             .Bind(() => DesignTimeBuild(args[0], args[1]))
-            .Bind<BuildalyzertBuildSuccess>(s => Collect(s.LockFilePath, s.TargetFramework))
-            .Bind<CollectDependenciesSuccess>(s => Analyze([..s.Dependencies], rm));
+            .Bind<BuildalyzerBuildSuccess>(s => Collect(s.LockFilePath, s.TargetFramework))
+            .Bind<CollectDependenciesSuccess>(s => Analyze([..s.Dependencies], rm))
+            .Tap(LogAndReturn);
 
-        return LogAndReturn(result) switch
+        return result switch
         {
             IExitCodeProvider provider => provider.ExitCode,
             ISuccessResult => ExitCodes.Success,
@@ -29,10 +30,9 @@ internal sealed class Program
         };
     }
 
-    private static Result LogAndReturn(Result result)
+    private static void LogAndReturn(Result result)
     {
         Console.WriteLine($"Execution result: {result}");
-        return result;
     }
 
     private static BuildalyzerBuildResult DesignTimeBuild(


### PR DESCRIPTION
## Summary
- add a `Tap` method to `ResultFunctionalExtensions`
- rename `BuildalyzertBuildSuccess` to `BuildalyzerBuildSuccess`
- use `Tap(LogAndReturn)` in `Program`

## Testing
- `dotnet test src/Fink.sln`

------
https://chatgpt.com/codex/tasks/task_e_68430d062b08832fbd989e551ed421a8